### PR TITLE
Allow -v or --valid flag to set number of days cert is valid for

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ docker run -v /dir/to/put/cert/in:/out qubyte/cert-creator -d <domain> -d <alt-d
 ```
 
  - At least one domain is required using the `-d` or `--domain` flag.
+ - Optionaly you may specify the number of days for which the generated certificate is valid (defaults to 1000) by setting `-v` or `--valid` flag with the number of days for instance `-v 825` to create a valid cert for MacOS 10.15+
  - A volume mount is required to place the key and certificate into.
 
 Once the pair are created, you need to install the `.pem` file into your browser

--- a/script.sh
+++ b/script.sh
@@ -3,6 +3,7 @@
 cp cert.conf.template cert.conf
 
 counter=1
+days_valid=1000
 
 while test $# -gt 0; do
     case "$1" in
@@ -20,6 +21,15 @@ while test $# -gt 0; do
                 shift
             fi
             ;;
+        -v|--valid)
+            shift
+            
+            if test $# -gt 0; then
+                days_valid="$1"
+                shift
+            fi
+            ;;
+                
         *)
             shift
             ;;
@@ -32,10 +42,10 @@ if [ -z "$first_domain" ]; then
 fi
 
 openssl genrsa 4096 > localCA.key
-openssl req -x509 -sha256 -new -nodes -key localCA.key -days 1000 -out localCA.pem -subj "/CN=$first_domain"
+openssl req -x509 -sha256 -new -nodes -key localCA.key -days $days_valid -out localCA.pem -subj "/CN=$first_domain"
 openssl genrsa 2048 > local.key
 openssl req -new -key local.key -subj "/CN=$first_domain" > local.csr
-openssl x509 -req -sha256 -days 1000 -CA localCA.pem -CAkey localCA.key -CAcreateserial -in local.csr -extfile cert.conf -extensions domain_devlocal > local.pem
+openssl x509 -req -sha256 -days $days_valid -CA localCA.pem -CAkey localCA.key -CAcreateserial -in local.csr -extfile cert.conf -extensions domain_devlocal > local.pem
 
 cp localCA.pem /out
 cp local.key /out


### PR DESCRIPTION
I've been using this nifty little tool for a while, but when generating a cert that will be used on MacOS 10.15+ it would appear that apple have stopped accepting any cert valid for more that 825 days, so I've simply added an option to set the validity length in days for a generated cert.

### usage:
docker run -v /dir/to/put/cert/in:/out qubyte/cert-creator -v 825 -d <domain> -d <alt-domain> -d <alt-domain>
further explanation added to readme.md

info here from apple:
https://support.apple.com/en-us/HT210176